### PR TITLE
Remove Twitter and Facebook

### DIFF
--- a/src/pages/Connect.js
+++ b/src/pages/Connect.js
@@ -27,18 +27,6 @@ const Connect = () => {
 			icon: faEnvelope,
 		},
 		{
-			name: "Facebook",
-			handle: "AdasTeamFB",
-			link: "https://www.facebook.com/AdasTeamFB/",
-			icon: ["fab", "facebook"],
-		},
-		{
-			name: "Twitter",
-			handle: "@adas_team",
-			link: "https://twitter.com/adas_team?lang=en",
-			icon: ["fab", "twitter"],
-		},
-		{
 			name: "Instagram",
 			handle: "@adas_team",
 			link: "https://www.instagram.com/adas_team/",


### PR DESCRIPTION
We are not updating our twitter or facebook, so it should not be linked anymore.
Removed links on the contact page.

Issue: 159