### PR TITLE
add relevant metadata

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,23 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
-		<title>Ada's Team</title>
+		<title>Ada's Team | University of Alberta Women in Computing & Technology</title>
+		
+		<!-- SEO Meta Tags -->
+		<meta name="description" content="Ada's Team promotes diversity and inclusivity in technology at the University of Alberta. We support women and underrepresented groups in computer science through events, mentorship, scholarships, and conferences." />
+		<meta name="keywords" content="UAlberta diversity, University of Alberta women in CS, women in computing, women in technology, computer science diversity, UAlberta computer science, women in STEM, tech diversity, inclusive tech, Ada's Team, underrepresented groups in tech, UAlberta tech community, WiCS, women in CS, diversity, University of Alberta, diversity" />
+		<meta name="author" content="Ada's Team" />
+		
+		<!-- Open Graph / Social Media Meta Tags -->
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content="Ada's Team | UAlberta Women in Computing & Technology" />
+		<meta property="og:description" content="Promoting diversity and inclusivity in technology at the University of Alberta. Join our community supporting women and underrepresented groups in computer science." />
+		<meta property="og:site_name" content="Ada's Team" />
+		
+		<!-- Twitter Card Meta Tags -->
+		<meta name="twitter:card" content="summary_large_image" />
+		<meta name="twitter:title" content="Ada's Team | UAlberta Women in Computing" />
+		<meta name="twitter:description" content="Promoting diversity and inclusivity in technology at the University of Alberta." />
 
 		<!-- Fonts -->
 		<link rel="preconnect" href="https://fonts.gstatic.com" />


### PR DESCRIPTION
Adas team website does not show up with simple searches like "ualberta women in cs". this way we will get more visibility. we also did not have meta data before and our descritpion with our website was not helpful nor talked about our mission.